### PR TITLE
added a button radius range slider to the custom example demo

### DIFF
--- a/public/customize.html
+++ b/public/customize.html
@@ -84,6 +84,11 @@
           <option value="uk">Ukrainian</option>
         </select>
       </label>
+      <label></label>
+      <label class="control">
+        <span>Button corner radius <span class="value"></span></span>
+        <input id="button-radius" type="range" min="0" max="100" value="4" />
+      </label>
       <label>
         <input id="button-custom" type="checkbox" />
         <span>Custom button size</span>
@@ -103,6 +108,7 @@
         environment="TEST"
         button-color="default"
         button-type="buy"
+        button-radius="4"
       ></google-pay-button>
     </div>
 

--- a/public/js/customize.js
+++ b/public/js/customize.js
@@ -55,6 +55,8 @@ const buttonColor = document.getElementById('button-color');
 /** @type {HTMLSelectElement} */
 const buttonType = document.getElementById('button-type');
 /** @type {HTMLSelectElement} */
+const buttonRadius = document.getElementById('button-radius');
+/** @type {HTMLSelectElement} */
 const buttonLocale = document.getElementById('button-locale');
 /** @type {HTMLInputElement} */
 const buttonCustom = document.getElementById('button-custom');
@@ -104,6 +106,11 @@ buttonHeight.addEventListener('change', event => {
   updateState();
 });
 
+buttonRadius.addEventListener('change', event => {  
+  button.buttonRadius = buttonRadius.value;
+  updateState();
+});
+
 function handleSliderInput(event) {
   const element = event.target.parentElement.querySelector('.value');
   element.textContent = `(${event.target.value}px)`;
@@ -111,6 +118,7 @@ function handleSliderInput(event) {
 
 buttonWidth.addEventListener('input', handleSliderInput);
 buttonHeight.addEventListener('input', handleSliderInput);
+buttonRadius.addEventListener('input', handleSliderInput);
 
 buttonLibrary.addEventListener('change', event => {
   library = buttonLibrary.value;
@@ -127,6 +135,7 @@ const container = document.getElementById('container');
 const button = googlePayClient.createButton({
   buttonColor: '${button.buttonColor || 'default'}',
   buttonType: '${button.buttonType || 'buy'}',
+  buttonRadius: ${button.buttonRadius || 4},
   ${button.buttonLocale ? `buttonLocale: \'${button.buttonLocale}\',` : '__empty__'}
   ${button.buttonSizeMode === 'fill' ? 'buttonSizeMode: \'fill\',' : '__empty__'}
   onClick: () => {},
@@ -141,6 +150,7 @@ container.appendChild(button);`,
   environment="TEST"
   buttonColor="${button.buttonColor || 'default'}"
   buttonType="${button.buttonType || 'buy'}"
+  buttonRadius="${button.buttonRadius || '4'}"
   ${button.buttonLocale ? `buttonLocale="${button.buttonLocale}"` : '__empty__'}
   ${button.buttonSizeMode === 'fill' ? 'buttonSizeMode="fill"' : '__empty__'}
   ${button.buttonSizeMode === 'fill' ? `style={{width: ${buttonWidth.value}, height: ${buttonHeight.value}}}` : '__empty__'}
@@ -152,6 +162,7 @@ container.appendChild(button);`,
   environment="TEST"
   buttonColor="${button.buttonColor || 'default'}"
   buttonType="${button.buttonType || 'buy'}"
+  buttonRadius="${button.buttonRadius || '4'}"
   ${button.buttonLocale ? `buttonLocale="${button.buttonLocale}"` : '__empty__'}
   ${button.buttonSizeMode === 'fill' ? 'buttonSizeMode="fill"' : '__empty__'}
   ${button.buttonSizeMode === 'fill' ? `style="width: ${buttonWidth.value}px; height: ${buttonHeight.value}px;"` : '__empty__'}
@@ -163,6 +174,7 @@ container.appendChild(button);`,
   environment="TEST"
   button-color="${button.buttonColor || 'default'}"
   button-type="${button.buttonType || 'buy'}"
+  button-radius="${button.buttonRadius || '4'}"
   ${button.buttonLocale ? `button-locale="${button.buttonLocale}"` : '__empty__'}
   ${button.buttonSizeMode === 'fill' ? 'button-size-mode="fill"' : '__empty__'}
   ${button.buttonSizeMode === 'fill' ? `style="width: ${buttonWidth.value}px; height: ${buttonHeight.value}px;"` : '__empty__'}


### PR DESCRIPTION
This change add a button radius range slider to the custom example demo:

<img width="881" alt="image" src="https://github.com/google-pay/gpay-live-demo/assets/4389374/9cfd81e2-bcdd-47a1-b23d-065f9b658ce0">
